### PR TITLE
fix call configure with file and block in builder

### DIFF
--- a/spec/totem/config_builder_spec.cr
+++ b/spec/totem/config_builder_spec.cr
@@ -1,6 +1,15 @@
 require "../spec_helper"
 
 module ConfigBuilderSpec
+  struct Config
+    include Totem::ConfigBuilder
+
+    build do
+      config_type "yaml"
+      config_paths ["/etc/totem", "~/.totem", "spec/fixtures"]
+    end
+  end
+
   struct Clothes
     include JSON::Serializable
 
@@ -13,15 +22,6 @@ module ConfigBuilderSpec
     property name : String
     property hobbies : Array(String)
     property clothing : Clothes
-
-    build do
-      config_type "yaml"
-      config_paths ["/etc/totem", "~/.totem", "spec/fixtures"]
-    end
-  end
-
-  struct Config
-    include Totem::ConfigBuilder
 
     build do
       config_type "yaml"
@@ -59,6 +59,16 @@ describe Totem::ConfigBuilder do
         config["hobbies"].size.should eq 3
         config["hobbies"].as_a.last.should eq "go"
         config["clothing"].as_h["jacket"].should eq "leather"
+      end
+
+      it "should works with given file and block" do
+        config = ConfigBuilderSpec::Config.configure("spec/fixtures/config.json") do |c|
+          c.set("name", "tavares")
+        end
+
+        config["name"].should eq "tavares"
+        config["batters"].size.should eq 1
+        config["batters"].as_h["batter"].as_a.first.as_h["type"].should eq "Regular"
       end
     end
 

--- a/src/totem/config_builder.cr
+++ b/src/totem/config_builder.cr
@@ -51,12 +51,12 @@ module Totem
       include JSON::Serializable
 
       def self.configure(file : String)
-        load_wit_file(file)
+        load_with_file(file)
         configure
       end
 
-      def self.configure(file : String, &block)
-        load_wit_file(file)
+      def self.configure(file : String, &block : Totem::Config -> _)
+        load_with_file(file)
         configure(&block)
       end
 
@@ -71,7 +71,7 @@ module Totem
         @@config.mapping(self)
       end
 
-      private def self.load_wit_file(file)
+      private def self.load_with_file(file)
         config_path = File.dirname(file)
         config_name = File.basename(file, File.extname(file))
         config_type = config_type(file)


### PR DESCRIPTION
```crystal
struct Config
  include Totem::ConfigBuilder

  build do
    config_type "yaml"
    config_paths ["/etc/totem", "~/.totem", "spec/fixtures"]
  end
end

Config.configure("/my/config/config.yaml") do |config|
end
```

complie error:

```
wrong number of block arguments (given 1, expected 0)
        Config.configure("/my/config/config.yaml") do |c|
                    ^~~~~~~
```