### PR TITLE
Compatibility with Crystal 0.27

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,20 +4,20 @@ version: 0.5.0
 authors:
   - icyleaf <icyleaf.cn@gmail.com>
 
-crystal: 0.26.1
+crystal: 0.27.0
 
 dependencies:
   popcorn:
     github: icyleaf/popcorn
-    version: ~> 0.2.0
+    version: ~> 0.2.1
 
 development_dependencies:
   poncho:
     github: icyleaf/poncho
-    version: ~> 0.1.0
+    version: ~> 0.3.0
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.0.0
+    version: ~> 2.1.1
   etcd:
     github: icyleaf/etcd-crystal
     version: ~> 0.2.1

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,5 +1,4 @@
 require "spec"
-require "tempfile"
 require "file_utils"
 require "../src/totem"
 require "../src/totem/config_types/*"
@@ -52,7 +51,7 @@ def env_spec_group(t)
   t.get("mysql_password").should eq "$wrwYAH3gQ"
 end
 
-SPEC_TEMPFILE_PATH = File.join(Tempfile.dirname, "totem-spec-#{Random.new.hex(8)}")
+SPEC_TEMPFILE_PATH = File.join(Dir.tempdir, "totem-spec-#{Random.new.hex(8)}")
 
 def with_tempfile(*paths, file = __FILE__)
   calling_spec = File.basename(file).rchop("_spec.cr")

--- a/spec/totem/config_spec.cr
+++ b/spec/totem/config_spec.cr
@@ -684,7 +684,7 @@ describe Totem::Config do
   end
 
   describe "remote providers" do
-    describe "with reds" do
+    describe "with redis" do
       it "should gets use key" do
         with_redis do |endpoint|
           t = Totem::Config.new


### PR DESCRIPTION
All changes to compatibility with Crystal 0.27 is remove `Tempfile` and rename `Tempfile.dirname` to `Dir.tempdir` in specs and update `popcorn` shard version.