### PR TITLE
Configure file insert position to config paths support

### DIFF
--- a/spec/totem/config_builder_spec.cr
+++ b/spec/totem/config_builder_spec.cr
@@ -43,7 +43,7 @@ describe Totem::ConfigBuilder do
       end
 
       it "should works with given file" do
-        config = ConfigBuilderSpec::Config.configure("spec/fixtures/config.json")
+        config = ConfigBuilderSpec::Config.configure("spec/fixtures/config.json", 0)
 
         config["name"].should eq "Cake"
         config["batters"].size.should eq 1

--- a/src/totem.cr
+++ b/src/totem.cr
@@ -5,23 +5,23 @@ module Totem
     Config.new(config_name, config_type, config_paths, key_delimiter: key_delimiter)
   end
 
-  def self.from_file(file : String, paths : Array(String)? = nil, key_delimiter : String? = ".")
+  def self.from_file(file : String, paths : Array(String)? = nil, key_delimiter : String = Config::KEY_DELIMITER)
     Config.from_file(file, paths, key_delimiter)
   end
 
-  def self.parse(raw : String, type : String, key_delimiter : String? = ".")
+  def self.parse(raw : String, type : String, key_delimiter : String = Config::KEY_DELIMITER)
     Config.parse(raw, type, key_delimiter)
   end
 
-  def self.from_json(raw : String, key_delimiter : String? = ".")
+  def self.from_json(raw : String, key_delimiter : String = Config::KEY_DELIMITER)
     parse(raw, "json", key_delimiter)
   end
 
-  def self.from_yaml(raw : String, key_delimiter : String? = ".")
+  def self.from_yaml(raw : String, key_delimiter : String = Config::KEY_DELIMITER)
     parse(raw, "yaml", key_delimiter)
   end
 
-  def self.from_env(raw : String, key_delimiter : String? = ".")
+  def self.from_env(raw : String, key_delimiter : String = Config::KEY_DELIMITER)
     parse(raw, "env", key_delimiter)
   end
 end

--- a/src/totem/config.cr
+++ b/src/totem/config.cr
@@ -44,6 +44,9 @@ module Totem
       instance
     end
 
+    CONFIG_NAME = "config"
+    KEY_DELIMITER = "."
+
     getter config_file : String?
     property config_paths
     property config_name
@@ -53,8 +56,8 @@ module Totem
 
     @remote_provider : RemoteProviders::Adapter?
 
-    def initialize(@config_name = "config", @config_type : String? = nil,
-                   @config_paths : Array(String) = [] of String, @key_delimiter = ".")
+    def initialize(@config_name = CONFIG_NAME, @config_type : String? = nil,
+                   @config_paths : Array(String) = [] of String, @key_delimiter = KEY_DELIMITER)
       @logger = Logger.new STDOUT, Logger::ERROR, formatter: default_logger_formatter
       @debugging = false
       @automatic_env = false
@@ -404,10 +407,10 @@ module Totem
     end
 
     def clear!
-      @config_name = "config"
+      @config_name = CONFIG_NAME
       @config_type = nil
       @config_paths = [] of String
-      @key_delimiter = "."
+      @key_delimiter = KEY_DELIMITER
 
       @logger = Logger.new STDOUT, Logger::ERROR, formatter: default_logger_formatter
       @debugging = false


### PR DESCRIPTION
Now configure file could insert position what you want into config paths.

```crystal
struct App
  include Totem::ConfigBuilder

  build do
    config_type "yaml"
    config_paths ["/etc", "~/.config/totem", "config"]
  end
end

config = App.configure("/data/config", 0)
config.config_paths # => ["/data/config", "/etc", "~/.config/totem", "config/"]
```